### PR TITLE
Single quotes break 'no posts' message

### DIFF
--- a/class-sticky-list.php
+++ b/class-sticky-list.php
@@ -699,7 +699,7 @@ if (class_exists("GFForms")) {
                                                     current_row.remove();
                                                     remaining_rows = $('#sticky-list-wrapper_$form_id tbody tr');
                                                     if(remaining_rows.length === 0) {
-                                                        $('#sticky-list-wrapper_$form_id table').html('" . $settings["empty_list_text"] . "');
+                                                        $('#sticky-list-wrapper_$form_id table').html('" . esc_js($settings["empty_list_text"]) . "');
                                                     }
                                                 });
                                             })


### PR DESCRIPTION
Add esc_js to prevent ' from breaking the "you have no posts" message display when deletion is on.
